### PR TITLE
Fix experience delete

### DIFF
--- a/src/controllers/experience.js
+++ b/src/controllers/experience.js
@@ -93,7 +93,7 @@ class ExperienceController {
 
   async update(req, res) {
     const { id } = req.params;
-    const userId = req.user.id; // Assume user ID is available from authentication middleware
+    const userId = req.user.id;
     const updatedData = req.body;
 
     const updateService = new UpdateExperience(id, userId, updatedData);
@@ -117,7 +117,6 @@ class ExperienceController {
           error: error.message,
         });
       }
-      // If there's an exception thrown by the service, catch it and respond with 500
       return res.status(500).json({ message: 'Failed to update experience' });
     }
   }

--- a/src/controllers/experience.js
+++ b/src/controllers/experience.js
@@ -1,11 +1,10 @@
 /* eslint-disable class-methods-use-this */
-// src/controllers/Experience.js
+
 import { validationResult } from 'express-validator';
 import db from '../models/index.js';
 import CreateExperience from '../services/experience/createExperience.js';
 import UpdateExperience from '../services/experience/updateExperience.js';
 import DeleteExperience from '../services/experience/deleteExperience.js';
-import { or } from 'sequelize';
 
 const { Experience, Employment, Education, User } = db;
 
@@ -14,7 +13,7 @@ class ExperienceController {
     // Validate the request
     const errors = validationResult(req);
     // Collect errors from express-validator and manual validation
-    let validationErrors = errors.array();
+    const validationErrors = errors.array();
 
     // Manually validate experienceType and organizationName
     const { experienceType, organizationName } = req.body;
@@ -26,7 +25,11 @@ class ExperienceController {
       });
     }
 
-    if (!organizationName || typeof organizationName !== 'string' || organizationName.trim() === '') {
+    if (
+      !organizationName
+        || typeof organizationName !== 'string'
+        || organizationName.trim() === ''
+    ) {
       validationErrors.push({
         param: 'organizationName',
         msg: 'organizationName is required and must be a non-empty string.',
@@ -39,15 +42,10 @@ class ExperienceController {
     }
 
     try {
-    
       // Delegate creation to the service layer
-      const experience = await new CreateExperience(req.body, req.user.id).call();
-
-      return res.status(201).json({
-        success: true,
-        message: 'Experience created successfully',
-        experience,
-      });
+      const response = await new CreateExperience(req.body, req.user.id).call();
+      const { statusCode, ...rest } = response;
+      return res.status(statusCode).json(rest);
     } catch (error) {
       return res.status(500).json({
         success: false,
@@ -98,7 +96,6 @@ class ExperienceController {
     const userId = req.user.id; // Assume user ID is available from authentication middleware
     const updatedData = req.body;
 
- 
     const updateService = new UpdateExperience(id, userId, updatedData);
     try {
       const result = await updateService.call();
@@ -106,15 +103,14 @@ class ExperienceController {
       if (!result.success) {
         return res.status(404).json({ error: result.error });
       }
-  
+
       return res.status(200).json({
         success: true,
         message: result.message,
         updatedExperience: result.updatedExperience,
       });
-    } catch (error){
-
-          // Check for specific error message and return a 404 if it's "Experience not found"
+    } catch (error) {
+      // Check for specific error message and return a 404 if it's "Experience not found"
       if (error.message === 'Experience not found') {
         return res.status(404).json({
           success: false,
@@ -124,56 +120,29 @@ class ExperienceController {
       // If there's an exception thrown by the service, catch it and respond with 500
       return res.status(500).json({ message: 'Failed to update experience' });
     }
-    
   }
 
   async remove(req, res) {
     const { experienceId } = req.params;
     const userId = req.user.id;
-   
+    const { id } = req.body;
 
     try {
       const user = await User.findByPk(userId);
       if (!user) { throw new Error('User not found'); }
 
-      const deleteService = new DeleteExperience(experienceId, user.id);
-      const result = await deleteService.call();
-
-
-      if (result.success) {
-        return res.status(204).send(); // Successfully deleted
-      }
-
-         // If it's a "not found" error from the delete service, return 404
-    if (result.error === 'Experience not found') {
-      return res.status(404).json({
-        success: false,
-        message: result.error,
-      });
-    }
-
-    // If any other error occurs, return 500
-    return res.status(500).json({
-      success: false,
-      message: 'Failed to delete experience',
-      error: result.error || 'Unknown error',
-    });
-    } 
-    catch (error) {
-      if (error.message === 'User not found') {
-        return res.status(404).json({
-          success: false,
-          message: error.message,
-        });
-      }
-
+      const deleteService = new DeleteExperience(experienceId, user.id, id);
+      const response = await deleteService.call();
+      const { statusCode, ...rest } = response;
+      return res.status(statusCode).json(rest);
+    } catch (error) {
       return res.status(500).json({
-        success: false, 
-        message: 'Failed to delete experience', 
-        error: error.message, 
+        success: false,
+        message: 'Failed to delete experience',
+        error: error.message,
       });
-     }
     }
   }
+}
 
 export default new ExperienceController();

--- a/src/migrations/20241109200048-create-experiences.cjs
+++ b/src/migrations/20241109200048-create-experiences.cjs
@@ -1,39 +1,39 @@
-'use strict';
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('Experiences', {
-      id: { 
-        type: Sequelize.INTEGER, 
-        autoIncrement: true, 
-        primaryKey: true, 
-        allowNull: false },
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false,
+      },
       userId: {
         type: Sequelize.INTEGER,
         allowNull: false,
-        references: { 
-          model: 'Users', 
-          key: 'id', 
+        references: {
+          model: 'Users',
+          key: 'id',
         },
-        onDelete: 'CASCADE',
+        onDelete: 'RESTRICT',
       },
-      experienceType: { 
+      experienceType: {
         type: Sequelize.ENUM('Education', 'Employment'),
-        allowNull: false, 
+        allowNull: false,
       },
-      organizationName: { 
-        type: Sequelize.STRING, 
-        allowNull: false, 
-        },
+      organizationName: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
       createdAt: {
-        allowNull: false, 
+        allowNull: false,
         type: Sequelize.DATE,
       },
       updatedAt: {
-        allowNull: false, 
+        allowNull: false,
         type: Sequelize.DATE,
-      }
+      },
     });
   },
 

--- a/src/migrations/20241109200048-create-experiences.cjs
+++ b/src/migrations/20241109200048-create-experiences.cjs
@@ -16,7 +16,7 @@ module.exports = {
           model: 'Users',
           key: 'id',
         },
-        onDelete: 'RESTRICT',
+        onDelete: 'CASCADE',
       },
       experienceType: {
         type: Sequelize.ENUM('Education', 'Employment'),

--- a/src/migrations/20241109200049-create-employments.cjs
+++ b/src/migrations/20241109200049-create-employments.cjs
@@ -1,30 +1,29 @@
-'use strict';
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('Employments', {
-      id: { 
-        type: Sequelize.INTEGER, 
-        autoIncrement: true, 
-        primaryKey: true, 
-        allowNull: false, 
-      },
-      jobTitle: { 
-        type: Sequelize.STRING, 
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
         allowNull: false,
       },
-      jobDescription: { 
-        type: Sequelize.TEXT, 
-        allowNull: true, 
+      jobTitle: {
+        type: Sequelize.STRING,
+        allowNull: false,
       },
-      startDate: { 
-        type: Sequelize.DATE, 
-        allowNull: false, 
+      jobDescription: {
+        type: Sequelize.TEXT,
+        allowNull: true,
       },
-      endDate: { 
-        type: Sequelize.DATE, 
-        allowNull: true, 
+      startDate: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      endDate: {
+        type: Sequelize.DATE,
+        allowNull: true,
         validate: {
           isAfterOrEqualToStartDate(value) {
             if (this.StartDate && value && value <= this.StartDate) {
@@ -35,12 +34,12 @@ module.exports = {
       },
       experienceId: {
         type: Sequelize.INTEGER,
-        references: { 
-          model: 'Experiences', 
-          key: 'id', 
+        references: {
+          model: 'Experiences',
+          key: 'id',
         },
-        allowNull: false, 
-        onDelete: 'CASCADE',
+        allowNull: false,
+        onDelete: 'RESTRICT',
       },
       createdAt: {
         allowNull: false,

--- a/src/migrations/20241109200049-create-employments.cjs
+++ b/src/migrations/20241109200049-create-employments.cjs
@@ -39,7 +39,7 @@ module.exports = {
           key: 'id',
         },
         allowNull: false,
-        onDelete: 'RESTRICT',
+        onDelete: 'CASCADE',
       },
       createdAt: {
         allowNull: false,

--- a/src/migrations/20241115191453-add-unique-constraint-to-education.cjs
+++ b/src/migrations/20241115191453-add-unique-constraint-to-education.cjs
@@ -2,13 +2,15 @@
 module.exports = {
   async up(queryInterface) {
     await queryInterface.addConstraint('Educations', {
-      fields: ['degree', 'experienceId'],
+      fields: ['degree', 'fieldOfStudy', 'experienceId'],
       type: 'unique',
-      name: 'unique_degree_per_experience', // Must match the index name if specified
+      name: 'unique_degree_and_field_of_study_per_experience',
     });
   },
 
   async down(queryInterface) {
-    await queryInterface.removeConstraint('Educations', 'unique_degree_per_experience');
+    await queryInterface.removeConstraint(
+      'Educations', 'unique_degree_and_field_of_study_per_experience'
+    );
   },
 };

--- a/src/migrations/20241115191453-add-unique-constraint-to-education.cjs
+++ b/src/migrations/20241115191453-add-unique-constraint-to-education.cjs
@@ -1,0 +1,14 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addConstraint('Educations', {
+      fields: ['degree', 'experienceId'],
+      type: 'unique',
+      name: 'unique_degree_per_experience', // Must match the index name if specified
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeConstraint('Educations', 'unique_degree_per_experience');
+  },
+};

--- a/src/migrations/20241115191721-add-unique-constraint-to-employment.cjs
+++ b/src/migrations/20241115191721-add-unique-constraint-to-employment.cjs
@@ -1,0 +1,14 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addConstraint('Employments', {
+      fields: ['jobTitle', 'experienceId'],
+      type: 'unique',
+      name: 'unique_job_title_per_experience', // Must match the index name if specified
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeConstraint('Employments', 'unique_job_title_per_experience');
+  },
+};

--- a/src/models/education.js
+++ b/src/models/education.js
@@ -32,19 +32,27 @@ export default (sequelize) => {
     },
     experienceId: {
       type: DataTypes.INTEGER,
-      primaryKey: true,
+      allowNull: false,
       references: {
         model: 'Experiences',
         key: 'id',
       },
+      onDelete: 'RESTRICT',
     },
   }, {
     tableName: 'Educations',
     timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['degree', 'experienceId'],
+        name: 'unique_degree_per_experience',
+      },
+    ],
   });
 
   Education.associate = (models) => {
-    Education.belongsTo(models.Experience, { foreignKey: 'experienceId' });
+    Education.belongsTo(models.Experience, { foreignKey: 'experienceId', onDelete: 'RESTRICT' });
   };
 
   return Education;

--- a/src/models/education.js
+++ b/src/models/education.js
@@ -37,7 +37,7 @@ export default (sequelize) => {
         model: 'Experiences',
         key: 'id',
       },
-      onDelete: 'RESTRICT',
+      onDelete: 'CASCADE',
     },
   }, {
     tableName: 'Educations',
@@ -45,8 +45,8 @@ export default (sequelize) => {
     indexes: [
       {
         unique: true,
-        fields: ['degree', 'experienceId'],
-        name: 'unique_degree_per_experience',
+        fields: ['degree', 'fieldOfStudy', 'experienceId'],
+        name: 'unique_degree_and_field_of_study_per_experience',
       },
     ],
   });

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -31,7 +31,7 @@ export default (sequelize) => {
         model: 'Experiences',
         key: 'id',
       },
-      onDelete: 'RESTRICT',
+      onDelete: 'CASCADE',
     },
   }, {
     tableName: 'Employments',

--- a/src/models/employment.js
+++ b/src/models/employment.js
@@ -1,4 +1,3 @@
-// src/models/Employment.js
 import { DataTypes } from 'sequelize';
 
 export default (sequelize) => {
@@ -28,19 +27,26 @@ export default (sequelize) => {
     },
     experienceId: {
       type: DataTypes.INTEGER,
-      primaryKey: true,
       references: {
         model: 'Experiences',
         key: 'id',
       },
+      onDelete: 'RESTRICT',
     },
   }, {
     tableName: 'Employments',
     timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['jobTitle', 'experienceId'],
+        name: 'unique_job_title_per_experience',
+      },
+    ],
   });
 
   Employment.associate = (models) => {
-    Employment.belongsTo(models.Experience, { foreignKey: 'experienceId' });
+    Employment.belongsTo(models.Experience, { foreignKey: 'experienceId', onDelete: 'RESTRICT' });
   };
 
   return Employment;

--- a/src/models/experience.js
+++ b/src/models/experience.js
@@ -1,4 +1,3 @@
-// src/models/Experience.js
 import { DataTypes } from 'sequelize';
 
 export default (sequelize) => {
@@ -17,16 +16,16 @@ export default (sequelize) => {
       allowNull: false,
       validate: {
         isIn: {
-          args: [['Education', 'Employment']], 
+          args: [['Education', 'Employment']],
           msg: 'experienceType must be either "Education" or "Employment"',
         },
       },
     },
-    
+
     organizationName: {
       type: DataTypes.STRING,
       allowNull: false,
-      // unique: true,
+      unique: true,
     },
   }, {
     tableName: 'Experiences',

--- a/src/routes/experience.js
+++ b/src/routes/experience.js
@@ -16,5 +16,4 @@ export default (app) => {
 
   // Delete a specific experience by ID (handles both Education and Employment experiences)
   app.delete('/api/v1/experiences/:experienceId', auth, experienceController.remove);
-
 };

--- a/src/services/experience/updateExperience.js
+++ b/src/services/experience/updateExperience.js
@@ -43,21 +43,20 @@ class UpdateExperience {
       };
     } catch (e) {
       throw new Error(e.message);
-      // return { success: false, error: e.message };
     }
   }
 
   // Private method to update Employment details
   async #updateEmployment(employmentData) {
     await Employment.update(employmentData, {
-      where: { experienceId: this.experienceId },
+      where: { experienceId: this.experienceId, id: employmentData.id },
     });
   }
 
   // Private method to update Education details
   async #updateEducation(educationData) {
     await Education.update(educationData, {
-      where: { experienceId: this.experienceId },
+      where: { experienceId: this.experienceId, id: educationData.id },
     });
   }
 }

--- a/src/services/experience/updateExperience.js
+++ b/src/services/experience/updateExperience.js
@@ -11,27 +11,25 @@ class UpdateExperience {
 
   async call() {
     try {
-
-   
       // Step 1: Update the base experience fields
       const [updated] = await Experience.update(this.updatedData, {
         where: { id: this.experienceId, userId: this.userId },
       });
 
       if (!updated) {
-        return { success: false, error: 'Experience not found' }; 
+        return { success: false, error: 'Experience not found' };
       }
 
-     // Step 2: Update related Employment or Education details if present in the updatedData
+      // Step 2: Update related Employment or Education details if present in the updatedData
       const experienceType = this.updatedData.experienceType
-      ? this.updatedData.experienceType.toUpperCase()
-      : null;
+        ? this.updatedData.experienceType.toUpperCase()
+        : null;
 
-    if (experienceType === 'EMPLOYMENT' && this.updatedData.employment) {
-      await this.#updateEmployment(this.updatedData.employment);
-    } else if (experienceType === 'EDUCATION' && this.updatedData.education) {
-      await this.#updateEducation(this.updatedData.education);
-    }
+      if (experienceType === 'EMPLOYMENT' && this.updatedData.employment) {
+        await this.#updateEmployment(this.updatedData.employment);
+      } else if (experienceType === 'EDUCATION' && this.updatedData.education) {
+        await this.#updateEducation(this.updatedData.education);
+      }
 
       // Step 3: Fetch and return the updated experience with associations
       const updatedExperience = await Experience.findByPk(this.experienceId, {
@@ -44,7 +42,7 @@ class UpdateExperience {
         updatedExperience,
       };
     } catch (e) {
-      throw new Error(e.message); 
+      throw new Error(e.message);
       // return { success: false, error: e.message };
     }
   }

--- a/tests/models/education.test.js
+++ b/tests/models/education.test.js
@@ -89,7 +89,7 @@ describe('Education Model', () => {
     ).rejects.toThrow('End date must be after or equal to the start date');
   });
 
-  test('should enforce unique degree per experience', async () => {
+  test('should enforce unique degree and field of study per experience', async () => {
     const user = await db.User.create({
       email: 'uniqueedu@example.com',
       password: 'password123',
@@ -113,7 +113,7 @@ describe('Education Model', () => {
     await expect(
       db.Education.create({
         degree: 'Bachelor of Arts', // Same degree
-        fieldOfStudy: 'Literature',
+        fieldOfStudy: 'History', // Same Field of Stidy
         startDate: new Date('2016-09-01'),
         experienceId: experience.id, // Same experienceId
       })

--- a/tests/models/user.test.js
+++ b/tests/models/user.test.js
@@ -6,9 +6,7 @@ describe('User Model', () => {
   beforeAll(async () => {
     try {
       await db.sequelize.authenticate();
-      console.log('Database connection established.');
       await db.sequelize.sync({ force: true });
-      console.log('Database synced successfully.');
     } catch (error) {
       console.error('Error during sync:', error);
     }


### PR DESCRIPTION
**What does this PR do?**

Fix ability to create duplicate education and employment for the same experience.
Make minor changes to the logic on the updateExperience and deleteExperience logic so it can work.
Fix failing tests related to the changes made

**List of task completed**

-   [x] Fixed ability to create duplicate education and employment for the same experience.
-   [x] Update  logic on the updateExperience and deleteExperience logic to ensure proper deleting and updating of experiences.
-  [x] Fix tests relating to changes made

**How can this be tested?**
Run `npm test`

**Additional info**
For the changes on the backend I made some changes that would require some migrations, I know its a bit inconvenient but this should be the last change that would be required: 

-  Run `npx sequelize db:drop` to drop local database
- Then Run `npm run db:setup` to create and run migrations